### PR TITLE
Add conda env file with working tensorflow and keras version for LPCNet

### DIFF
--- a/LPCNet.yml
+++ b/LPCNet.yml
@@ -1,0 +1,24 @@
+#
+# install
+# conda env create -f=LPCNet.yml
+#
+# update
+# conda env update -f=LPCNet.yml
+#
+# activate
+# conda activate LPCNet
+#
+# remove
+# conda remove --name LPCNet --all
+#
+name: LPCNet
+channels:
+  - anaconda
+  - conda-forge
+dependencies:
+  - keras==2.2.4
+  - python>=3.6
+  - tensorflow-gpu==1.12.0
+  - cudatoolkit
+  - h5py
+  - numpy


### PR DESCRIPTION
train_lpcnet.py is not working properly with tensorflow2 and new keras version. Adding a conda env file to track working versions.