### PR TITLE
Open files in binary mode to enable dump_data to work properly on Win…

### DIFF
--- a/src/dump_data.c
+++ b/src/dump_data.c
@@ -171,7 +171,7 @@ int main(int argc, char **argv) {
     fprintf(stderr,"Error opening input .s16 16kHz speech input file: %s\n", argv[2]);
     exit(1);
   }
-  ffeat = fopen(argv[3], "w");
+  ffeat = fopen(argv[3], "wb");
   if (ffeat == NULL) {
     fprintf(stderr,"Error opening output feature file: %s\n", argv[3]);
     exit(1);
@@ -194,7 +194,7 @@ int main(int argc, char **argv) {
     return 0;
   }
   if (training) {
-    fpcm = fopen(argv[4], "w");
+    fpcm = fopen(argv[4], "wb");
     if (fpcm == NULL) {
       fprintf(stderr,"Error opening output PCM file: %s\n", argv[4]);
       exit(1);


### PR DESCRIPTION
…dows

features.f32 and data.u8 got corrupted when writing on windows.

Open in binary mode ensures works well cross platform.