### PR TITLE
test_vec fix

### DIFF
--- a/src/test_vec.c
+++ b/src/test_vec.c
@@ -19,14 +19,16 @@
 #define sgemv_accum16 sgemv_accum16_fast
 #define sparse_sgemv_accum16 sparse_sgemv_accum16_fast
 
-#ifdef __AVX__
+#if defined(__AVX__) || defined(__SSE2__)
 #include "vec_avx.h"
-#ifdef __AVX2__
+#if defined(__AVX2__)
 const char simd[]="AVX2";
-#else
+#elif defined(__AVX__)
 const char simd[]="AVX";
+#else
+const char simd[]="SSE";
 #endif
-#elif __ARM_NEON__
+#elif defined(__ARM_NEON__)
 #include "vec_neon.h"
 const char simd[]="NEON";
 #else

--- a/src/test_vec.c
+++ b/src/test_vec.c
@@ -42,6 +42,8 @@ const char simd[]="none";
 #undef vec_sigmoid
 #undef sgemv_accum16
 #undef sparse_sgemv_accum16
+#define sgemv_accum8x4 sgemv_accum8x4_nosimd
+#define sparse_sgemv_accum8x4 sparse_sgemv_accum8x4_nosimd
 #include "vec.h"
 
 #define ROW_STEP 16

--- a/src/test_vec.c
+++ b/src/test_vec.c
@@ -122,11 +122,90 @@ int test_sparse_sgemv_accum16() {
     return 0;
 }
 
+#ifndef DOT_PROD
+#define test_sgemv_accum8x4()		0
+#define test_sparse_sgemv_accum8x4()	0
+#else
+int test_sgemv_accum8x4() {
+    qweight w[ROWS*COLS];
+    float x[COLS];
+    float out_nosimd[ROWS], out[ROWS];
+    int i;
+
+    printf("sgemv_accum8x4....................: ");
+    for(i=0; i<ROWS*COLS; i++) {
+	w[i] = i;
+    }
+    for(i=0; i<ROWS; i++) {
+	out_nosimd[i] = 0;
+	out[i] = 0;
+    }
+
+    for(i=0; i<COLS; i++) {
+	x[i] = i+1;
+    }
+
+    sgemv_accum8x4_nosimd(out_nosimd, w, ROWS, COLS, 1, x);
+    sgemv_accum8x4(out, w, ROWS, COLS, 1, x);
+
+    for(i=0; i<ROWS; i++) {
+	if (out_nosimd[i] != out[i]) {
+	    printf("fail\n");
+	    for(i=0; i<ROWS; i++) {
+		printf("%d %f %f\n", i, out_nosimd[i], out[i]);
+		if (out_nosimd[i] != out[i])
+		    return 1;
+	    }
+	}
+    }
+
+    printf("pass\n");
+    return 0;
+}
+
+
+int test_sparse_sgemv_accum8x4() {
+    int rows = ROW_STEP*ENTRIES;
+    int indx[] = {1,0,2,0,1};
+    qweight w[ROW_STEP*(1+2)];
+    float x[ENTRIES] = {1,2};
+    float out_nosimd[ROW_STEP*(1+2)], out[ROW_STEP*(1+2)];
+    int i;
+
+    printf("sparse_sgemv_accum8x4.............: ");
+    for(i=0; i<ROW_STEP*(1+2); i++) {
+	w[i] = i;
+	out_nosimd[i] = 0;
+	out[i] = 0;
+    }
+
+    sparse_sgemv_accum8x4_nosimd(out_nosimd, w, rows, 1, indx, x);
+    sparse_sgemv_accum8x4(out, w, rows, 1, indx, x);
+
+    for(i=0; i<ROW_STEP*ENTRIES; i++) {
+	if (out_nosimd[i] != out[i]) {
+	    printf("fail\n");
+	    for(i=0; i<ROW_STEP*ENTRIES; i++) {
+		printf("%d %f %f\n", i, out_nosimd[i], out[i]);
+		if (out_nosimd[i] != out[i])
+		    return 1;
+	    }
+	}
+    }
+
+    printf("pass\n");
+    return 0;
+}
+#endif
+
 int main() {
     printf("testing vector routines on SIMD: %s\n", simd);
     int test1 = test_sgemv_accum16();
     int test2 = test_sparse_sgemv_accum16();
-    return test1 || test2;
+    int test3 = test_sgemv_accum8x4();
+    int test4 = test_sparse_sgemv_accum8x4();
+
+    return test1 || test2 || test3 || test4;
 }
 
   

--- a/src/vec.h
+++ b/src/vec.h
@@ -345,7 +345,9 @@ static inline void sparse_sgemv_accum8x4(float *out, const qweight *w, int rows,
 
 #else /*DOT_PROD*/
 
+#ifndef LPCNET_TEST
 #define sgemv_accum8x4 sgemv_accum
+#endif
 
 
 static inline void sparse_sgemv_accum8x4(float *out, const qweight *w, int rows, int ignore, const int *idx, const float *x)

--- a/src/vec.h
+++ b/src/vec.h
@@ -35,15 +35,19 @@
 #include "arch.h"
 
 
-#if defined(__AVX__) || defined(__SSE2__)
+#if defined(LPCNET_TEST)
+#define NO_OPTIMIZATIONS
+#elif defined(__AVX__) || defined(__SSE2__)
 #include "vec_avx.h"
 #elif defined(__ARM_NEON__) || defined(__ARM_NEON)
 #include "vec_neon.h"
 #else
+#define NO_OPTIMIZATIONS
+#endif
+
+#ifdef NO_OPTIMIZATIONS
 
 #define MAX_INPUTS (2048)
-
-#define NO_OPTIMIZATIONS
 
 #ifndef DISABLE_DOT_PROD
 #define DOT_PROD

--- a/src/vec_avx.h
+++ b/src/vec_avx.h
@@ -858,7 +858,9 @@ static inline void sparse_sgemv_accum8x4(float *_out, const qweight *w, int rows
 
 #else /*DOT_PROD*/
 typedef float qweight;
+#ifndef LPCNET_TEST
 #define sgemv_accum8x4 sgemv_accum
+#endif
 
 static inline void sparse_sgemv_accum8x4(float *out, const qweight *weights, int rows, int ignore, const int *idx, const float *x)
 {


### PR DESCRIPTION
This is a remedy for issue #155, and I added tests for sgemv_accum8x4() and sparse_sgemv_accum8x4().
Test for sparse_sgemv_accum8x4() is incomplete, multiple column test is not supported.
