### PR TITLE
Windows build fixes

### DIFF
--- a/download_model.bat
+++ b/download_model.bat
@@ -1,0 +1,10 @@
+@echo off
+set model=lpcnet_data-%1.tar.gz
+
+if not exist %model% (
+    echo Downloading latest model
+    powershell -Command "(New-Object System.Net.WebClient).DownloadFile('https://media.xiph.org/lpcnet/data/%model%', '%model%')"
+)
+
+tar -xvzf %model%
+

--- a/src/common.c
+++ b/src/common.c
@@ -40,7 +40,7 @@ static void single_interp(float *x, const float *left, const float *right, int i
     float ref[NB_BANDS];
     float pred[3*NB_BANDS];
     RNN_COPY(ref, x, NB_BANDS);
-    for (i=0;i<NB_BANDS;i++) pred[i] = .5*(left[i] + right[i]);
+    for (i=0;i<NB_BANDS;i++) pred[i] = .5f*(left[i] + right[i]);
     for (i=0;i<NB_BANDS;i++) pred[NB_BANDS+i] = left[i];
     for (i=0;i<NB_BANDS;i++) pred[2*NB_BANDS+i] = right[i];
     for (i=0;i<NB_BANDS;i++) {

--- a/src/common.h
+++ b/src/common.h
@@ -36,8 +36,8 @@ static RNN_INLINE float ulaw2lin(float u)
 {
     float s;
     float scale_1 = 32768.f/255.f;
-    u = u - 128;
-    s = u >= 0 ? 1 : -1;
+    u = u - 128.f;
+    s = u >= 0.f ? 1.f : -1.f;
     u = fabs(u);
     return s*scale_1*(exp(u/128.*LOG256)-1);
 }

--- a/src/lpcnet.c
+++ b/src/lpcnet.c
@@ -155,7 +155,7 @@ LPCNET_EXPORT int lpcnet_init(LPCNetState *lpcnet)
     memset(lpcnet, 0, lpcnet_get_size());
     lpcnet->last_exc = lin2ulaw(0.f);
     for (i=0;i<256;i++) {
-        float prob = .025+.95*i/255.;
+        float prob = .025f+.95f*i/255.f;
         lpcnet->sampling_logit_table[i] = -log((1-prob)/prob);
     }
     kiss99_srand(&lpcnet->rng, (const unsigned char *)rng_string, strlen(rng_string));

--- a/src/lpcnet_dec.c
+++ b/src/lpcnet_dec.c
@@ -121,13 +121,13 @@ void decode_packet(float features[4][NB_TOTAL_FEATURES], float *vq_mem, const un
   }
   for (sub=0;sub<4;sub++) {
     float p = pow(2.f, main_pitch/21.)*PITCH_MIN_PERIOD;
-    p *= 1 + modulation/16./7.*(2*sub-3);
+    p *= 1.f + modulation/16.f/7.f*(2*sub-3);
     p = MIN16(255, MAX16(33, p));
-    features[sub][NB_BANDS] = .02*(p-100);
-    features[sub][NB_BANDS + 1] = frame_corr-.5;
+    features[sub][NB_BANDS] = .02f*(p-100.f);
+    features[sub][NB_BANDS + 1] = frame_corr-.5f;
   }
   
-  features[3][0] = (c0_id-64)/4.;
+  features[3][0] = (c0_id-64)/4.f;
   for (i=0;i<NB_BANDS_1;i++) {
     features[3][i+1] = ceps_codebook1[vq_end[0]*NB_BANDS_1 + i] + ceps_codebook2[vq_end[1]*NB_BANDS_1 + i] + ceps_codebook3[vq_end[2]*NB_BANDS_1 + i];
   }
@@ -141,7 +141,7 @@ void decode_packet(float features[4][NB_TOTAL_FEATURES], float *vq_mem, const un
     features[1][i] = sign*ceps_codebook_diff4[vq_mid*NB_BANDS + i];
   }
   if ((vq_mid&MULTI_MASK) < 2) {
-    for (i=0;i<NB_BANDS;i++) features[1][i] += .5*(vq_mem[i] + features[3][i]);
+    for (i=0;i<NB_BANDS;i++) features[1][i] += .5f*(vq_mem[i] + features[3][i]);
   } else if ((vq_mid&MULTI_MASK) == 2) {
     for (i=0;i<NB_BANDS;i++) features[1][i] += vq_mem[i];
   } else {

--- a/src/lpcnet_enc.c
+++ b/src/lpcnet_enc.c
@@ -52,7 +52,7 @@
 void vq_quantize_mbest(const float *codebook, int nb_entries, const float *x, int ndim, int mbest, float *dist, int *index)
 {
   int i, j;
-  for (i=0;i<mbest;i++) dist[i] = 1e15;
+  for (i=0;i<mbest;i++) dist[i] = 1e15f;
   
   for (i=0;i<nb_entries;i++)
   {
@@ -80,7 +80,7 @@ void vq_quantize_mbest(const float *codebook, int nb_entries, const float *x, in
 int vq_quantize(const float *codebook, int nb_entries, const float *x, int ndim, float *dist_out)
 {
   int i, j;
-  float min_dist = 1e15;
+  float min_dist = 1e15f;
   int nearest = 0;
   
   for (i=0;i<nb_entries;i++)
@@ -242,7 +242,7 @@ int quantize_3stage_mbest(float *x, int entry[3])
 static int find_nearest_multi(const float *codebook, int nb_entries, const float *x, int ndim, float *dist_out, int sign)
 {
   int i, j;
-  float min_dist = 1e15;
+  float min_dist = 1e15f;
   int nearest = 0;
 
   for (i=0;i<nb_entries;i++)
@@ -290,7 +290,7 @@ int quantize_diff(float *x, float *left, float *right, float *codebook, int bits
     float s = 1;
     nb_entries = 1<<bits;
     RNN_COPY(ref, x, NB_BANDS);
-    for (i=0;i<NB_BANDS;i++) pred[i] = pred[NB_BANDS+i] = .5*(left[i] + right[i]);
+    for (i=0;i<NB_BANDS;i++) pred[i] = pred[NB_BANDS+i] = .5f*(left[i] + right[i]);
     for (i=0;i<NB_BANDS;i++) pred[2*NB_BANDS+i] = left[i];
     for (i=0;i<NB_BANDS;i++) pred[3*NB_BANDS+i] = right[i];
     for (i=0;i<4*NB_BANDS;i++) target[i] = x[i%NB_BANDS] - pred[i];
@@ -319,10 +319,10 @@ int quantize_diff(float *x, float *left, float *right, float *codebook, int bits
 int interp_search(const float *x, const float *left, const float *right, float *dist_out)
 {
     int i, k;
-    float min_dist = 1e15;
+    float min_dist = 1e15f;
     int best_pred = 0;
     float pred[4*NB_BANDS];
-    for (i=0;i<NB_BANDS;i++) pred[i] = pred[NB_BANDS+i] = .5*(left[i] + right[i]);
+    for (i=0;i<NB_BANDS;i++) pred[i] = pred[NB_BANDS+i] = .5f*(left[i] + right[i]);
     for (i=0;i<NB_BANDS;i++) pred[2*NB_BANDS+i] = left[i];
     for (i=0;i<NB_BANDS;i++) pred[3*NB_BANDS+i] = right[i];
 
@@ -342,7 +342,7 @@ int interp_search(const float *x, const float *left, const float *right, float *
 void interp_diff(float *x, float *left, float *right, float *codebook, int bits, int sign)
 {
     int i, k;
-    float min_dist = 1e15;
+    float min_dist = 1e15f;
     int best_pred = 0;
     float ref[NB_BANDS];
     float pred[4*NB_BANDS];
@@ -350,7 +350,7 @@ void interp_diff(float *x, float *left, float *right, float *codebook, int bits,
     (void)codebook;
     (void)bits;
     RNN_COPY(ref, x, NB_BANDS);
-    for (i=0;i<NB_BANDS;i++) pred[i] = pred[NB_BANDS+i] = .5*(left[i] + right[i]);
+    for (i=0;i<NB_BANDS;i++) pred[i] = pred[NB_BANDS+i] = .5f*(left[i] + right[i]);
     for (i=0;i<NB_BANDS;i++) pred[2*NB_BANDS+i] = left[i];
     for (i=0;i<NB_BANDS;i++) pred[3*NB_BANDS+i] = right[i];
 
@@ -378,7 +378,7 @@ void interp_diff(float *x, float *left, float *right, float *codebook, int bits,
 int double_interp_search(float features[4][NB_TOTAL_FEATURES], const float *mem) {
     int i, j;
     int best_id=0;
-    float min_dist = 1e15;
+    float min_dist = 1e15f;
     float dist[2][3];
     interp_search(features[0], mem, features[1], dist[0]);
     interp_search(features[2], features[1], features[3], dist[1]);
@@ -410,12 +410,12 @@ void perform_interp_relaxation(float features[4][NB_TOTAL_FEATURES], const float
     id1 = best_id % 3;
     count = 1;
     if (id0 != 1) {
-        float t = (id0==0) ? .5 : 1.;
+        float t = (id0==0) ? .5f : 1.f;
         for (i=0;i<NB_BANDS;i++) features[1][i] += t*features[0][i];
         count += t;
     }
     if (id1 != 2) {
-        float t = (id1==0) ? .5 : 1.;
+        float t = (id1==0) ? .5f : 1.f;
         for (i=0;i<NB_BANDS;i++) features[1][i] += t*features[2][i];
         count += t;
     }
@@ -511,9 +511,9 @@ void compute_frame_features(LPCNetEncState *st, const float *in) {
   follow = -2;
   for (i=0;i<NB_BANDS;i++) {
     Ly[i] = log10(1e-2+Ex[i]);
-    Ly[i] = MAX16(logMax-8, MAX16(follow-2.5, Ly[i]));
+    Ly[i] = MAX16(logMax-8, MAX16(follow-2.5f, Ly[i]));
     logMax = MAX16(logMax, Ly[i]);
-    follow = MAX16(follow-2.5, Ly[i]);
+    follow = MAX16(follow-2.5f, Ly[i]);
     E += Ex[i];
   }
   dct(st->features[st->pcount], Ly);
@@ -529,7 +529,7 @@ void compute_frame_features(LPCNetEncState *st, const float *in) {
       sum += st->lpc[j]*st->pitch_mem[j];
     RNN_MOVE(st->pitch_mem+1, st->pitch_mem, LPC_ORDER-1);
     st->pitch_mem[0] = aligned_in[i];
-    st->exc_buf[PITCH_MAX_PERIOD+i] = sum + .7*st->pitch_filt;
+    st->exc_buf[PITCH_MAX_PERIOD+i] = sum + .7f*st->pitch_filt;
     st->pitch_filt = sum;
     /*printf("%f\n", st->exc_buf[PITCH_MAX_PERIOD+i]);*/
   }
@@ -548,7 +548,7 @@ void compute_frame_features(LPCNetEncState *st, const float *in) {
       /* Upsample correlation by 3x and keep the max. */
       float interpolated[PITCH_MAX_PERIOD]={0};
       /* interp=sinc([-3:3]+1/3).*(.5+.5*cos(pi*[-3:3]/4.5)); interp=interp/sum(interp); */
-      static const float interp[7] = {0.026184, -0.098339, 0.369938, 0.837891, -0.184969, 0.070242, -0.020947};
+      static const float interp[7] = {0.026184f, -0.098339f, 0.369938f, 0.837891f, -0.184969f, 0.070242f, -0.020947f};
       for (i=4;i<PITCH_MAX_PERIOD-4;i++) {
         float val1=0, val2=0;
         int j;
@@ -582,7 +582,7 @@ void process_superframe(LPCNetEncState *st, unsigned char *buf, FILE *ffeat, int
   float sx=0, sxx=0, sxy=0, sy=0, sw=0;
   float frame_corr;
   int voiced;
-  float frame_weight_sum = 1e-15;
+  float frame_weight_sum = 1e-15f;
   float center_pitch;
   int main_pitch;
   int modulation;
@@ -594,11 +594,11 @@ void process_superframe(LPCNetEncState *st, unsigned char *buf, FILE *ffeat, int
   for(sub=0;sub<8;sub++) frame_weight_sum += st->frame_weight[2+sub];
   for(sub=0;sub<8;sub++) st->frame_weight[2+sub] *= (8.f/frame_weight_sum);
   for(sub=0;sub<8;sub++) {
-    float max_path_all = -1e15;
+    float max_path_all = -1e15f;
     best_i = 0;
     for (i=0;i<PITCH_MAX_PERIOD-2*PITCH_MIN_PERIOD;i++) {
       float xc_half = MAX16(MAX16(st->xc[2+sub][(PITCH_MAX_PERIOD+i)/2], st->xc[2+sub][(PITCH_MAX_PERIOD+i+2)/2]), st->xc[2+sub][(PITCH_MAX_PERIOD+i-1)/2]);
-      if (st->xc[2+sub][i] < xc_half*1.1) st->xc[2+sub][i] *= .8;
+      if (st->xc[2+sub][i] < xc_half*1.1f) st->xc[2+sub][i] *= .8f;
     }
     for (i=0;i<PITCH_MAX_PERIOD-PITCH_MIN_PERIOD;i++) {
       int j;
@@ -666,7 +666,7 @@ void process_superframe(LPCNetEncState *st, unsigned char *buf, FILE *ffeat, int
   /*best_b = (sxx*sy - sx*sxy)/(sw*sxx - sx*sx);*/
   best_b = (sy - best_a*sx)/sw;
   /* Quantizing the pitch as "main" pitch + slope. */
-  center_pitch = best_b+5.5*best_a;
+  center_pitch = best_b+5.5f*best_a;
   main_pitch = (int)floor(.5 + 21.*log2(center_pitch/PITCH_MIN_PERIOD));
   main_pitch = IMAX(0, IMIN(63, main_pitch));
   modulation = (int)floor(.5 + 16*7*best_a/center_pitch);
@@ -677,13 +677,13 @@ void process_superframe(LPCNetEncState *st, unsigned char *buf, FILE *ffeat, int
   for (sub=0;sub<4;sub++) {
     if (quantize) {
       float p = pow(2.f, main_pitch/21.)*PITCH_MIN_PERIOD;
-      p *= 1 + modulation/16./7.*(2*sub-3);
+      p *= 1.f + modulation/16.f/7.f*(2*sub-3);
       p = MIN16(255, MAX16(33, p));
-      st->features[sub][NB_BANDS] = .02*(p-100);
-      st->features[sub][NB_BANDS + 1] = frame_corr-.5;
+      st->features[sub][NB_BANDS] = .02f*(p-100);
+      st->features[sub][NB_BANDS + 1] = frame_corr-.5f;
     } else {
-      st->features[sub][NB_BANDS] = .01*(IMAX(66, IMIN(510, best[2+2*sub]+best[2+2*sub+1]))-200);
-      st->features[sub][NB_BANDS + 1] = frame_corr-.5;
+      st->features[sub][NB_BANDS] = .01f*(IMAX(66, IMIN(510, best[2+2*sub]+best[2+2*sub+1]))-200);
+      st->features[sub][NB_BANDS + 1] = frame_corr-.5f;
     }
     /*printf("%f %d %f\n", st->features[sub][NB_BANDS], best[2+2*sub], frame_corr);*/
   }
@@ -694,7 +694,7 @@ void process_superframe(LPCNetEncState *st, unsigned char *buf, FILE *ffeat, int
     /*printf("%f\n", st->features[3][0]);*/
     c0_id = (int)floor(.5 + st->features[3][0]*4);
     c0_id = IMAX(-64, IMIN(63, c0_id));
-    st->features[3][0] = c0_id/4.;
+    st->features[3][0] = c0_id/4.f;
     quantize_3stage_mbest(&st->features[3][1], vq_end);
     /*perform_interp_relaxation(st->features, st->vq_mem);*/
     quantize_diff(&st->features[1][0], st->vq_mem, &st->features[3][0], ceps_codebook_diff4, 12, 1, &vq_mid);
@@ -736,15 +736,15 @@ void process_multi_frame(LPCNetEncState *st, FILE *ffeat) {
   int best[10];
   int pitch_prev[8][PITCH_MAX_PERIOD];
   float frame_corr;
-  float frame_weight_sum = 1e-15;
+  float frame_weight_sum = 1e-15f;
   for(sub=0;sub<8;sub++) frame_weight_sum += st->frame_weight[2+sub];
   for(sub=0;sub<8;sub++) st->frame_weight[2+sub] *= (8.f/frame_weight_sum);
   for(sub=0;sub<8;sub++) {
-    float max_path_all = -1e15;
+    float max_path_all = -1e15f;
     best_i = 0;
     for (i=0;i<PITCH_MAX_PERIOD-2*PITCH_MIN_PERIOD;i++) {
       float xc_half = MAX16(MAX16(st->xc[2+sub][(PITCH_MAX_PERIOD+i)/2], st->xc[2+sub][(PITCH_MAX_PERIOD+i+2)/2]), st->xc[2+sub][(PITCH_MAX_PERIOD+i-1)/2]);
-      if (st->xc[2+sub][i] < xc_half*1.1) st->xc[2+sub][i] *= .8;
+      if (st->xc[2+sub][i] < xc_half*1.1) st->xc[2+sub][i] *= .8f;
     }
     for (i=0;i<PITCH_MAX_PERIOD-PITCH_MIN_PERIOD;i++) {
       int j;
@@ -781,8 +781,8 @@ void process_multi_frame(LPCNetEncState *st, FILE *ffeat) {
   }
   frame_corr /= 8;
   for (sub=0;sub<4;sub++) {
-    st->features[sub][NB_BANDS] = .01*(IMAX(66, IMIN(510, best[2+2*sub]+best[2+2*sub+1]))-200);
-    st->features[sub][NB_BANDS + 1] = frame_corr-.5;
+    st->features[sub][NB_BANDS] = .01f*(IMAX(66, IMIN(510, best[2+2*sub]+best[2+2*sub+1]))-200);
+    st->features[sub][NB_BANDS + 1] = frame_corr-.5f;
     /*printf("%f %d %f\n", st->features[sub][NB_BANDS], best[2+2*sub], frame_corr);*/
   }
   /*printf("%d %f %f %f\n", best_period, best_a, best_b, best_corr);*/
@@ -804,15 +804,15 @@ void process_single_frame(LPCNetEncState *st, FILE *ffeat) {
   int best[4];
   int pitch_prev[2][PITCH_MAX_PERIOD];
   float frame_corr;
-  float frame_weight_sum = 1e-15;
+  float frame_weight_sum = 1e-15f;
   for(sub=0;sub<2;sub++) frame_weight_sum += st->frame_weight[2+2*st->pcount+sub];
   for(sub=0;sub<2;sub++) st->frame_weight[2+2*st->pcount+sub] *= (2.f/frame_weight_sum);
   for(sub=0;sub<2;sub++) {
-    float max_path_all = -1e15;
+    float max_path_all = -1e15f;
     best_i = 0;
     for (i=0;i<PITCH_MAX_PERIOD-2*PITCH_MIN_PERIOD;i++) {
       float xc_half = MAX16(MAX16(st->xc[2+2*st->pcount+sub][(PITCH_MAX_PERIOD+i)/2], st->xc[2+2*st->pcount+sub][(PITCH_MAX_PERIOD+i+2)/2]), st->xc[2+2*st->pcount+sub][(PITCH_MAX_PERIOD+i-1)/2]);
-      if (st->xc[2+2*st->pcount+sub][i] < xc_half*1.1) st->xc[2+2*st->pcount+sub][i] *= .8;
+      if (st->xc[2+2*st->pcount+sub][i] < xc_half*1.1) st->xc[2+2*st->pcount+sub][i] *= .8f;
     }
     for (i=0;i<PITCH_MAX_PERIOD-PITCH_MIN_PERIOD;i++) {
       int j;
@@ -848,8 +848,8 @@ void process_single_frame(LPCNetEncState *st, FILE *ffeat) {
     best_i = pitch_prev[sub][best_i];
   }
   frame_corr /= 2;
-  st->features[st->pcount][NB_BANDS] = .01*(IMAX(66, IMIN(510, best[2]+best[3]))-200);
-  st->features[st->pcount][NB_BANDS + 1] = frame_corr-.5;
+  st->features[st->pcount][NB_BANDS] = .01f*(IMAX(66, IMIN(510, best[2]+best[3]))-200);
+  st->features[st->pcount][NB_BANDS + 1] = frame_corr-.5f;
   if (ffeat) {
     fwrite(st->features[st->pcount], sizeof(float), NB_TOTAL_FEATURES, ffeat);
   }

--- a/src/nnet.c
+++ b/src/nnet.c
@@ -41,7 +41,11 @@
 #include "plc_data.h"
 
 #ifdef NO_OPTIMIZATIONS
+#if defined(_MSC_VER)
+#pragma message ("Compiling without any vectorization. This code will be very slow")
+#else
 #warning Compiling without any vectorization. This code will be very slow
+#endif
 #endif
 
 

--- a/src/test_vec.c
+++ b/src/test_vec.c
@@ -10,7 +10,7 @@
 // we need to call two versions of each functions that have the same
 // name, so use #defines to temp rename them
 
-#define celt_exp2 celt_exp2_fast
+#define lpcnet_exp2 lpcnet_exp2_fast
 #define tansig_approx tansig_approx_fast
 #define sigmoid_approx sigmoid_approx_fast
 #define softmax softmax_fast
@@ -34,7 +34,7 @@ const char simd[]="none";
 
 #endif
 
-#undef celt_exp2
+#undef lpcnet_exp2
 #undef tansig_approx
 #undef sigmoid_approx
 #undef softmax

--- a/src/vec.h
+++ b/src/vec.h
@@ -59,7 +59,7 @@ typedef float qweight;
 
 /* No AVX2/FMA support */
 #ifndef LPCNET_TEST
-static inline float celt_exp2(float x)
+static inline float lpcnet_exp2(float x)
 {
    int integer;
    float frac;
@@ -77,7 +77,7 @@ static inline float celt_exp2(float x)
    res.i = (res.i + (integer<<23)) & 0x7fffffff;
    return res.f;
 }
-#define celt_exp(x) celt_exp2((x)*1.44269504f)
+#define lpcnet_exp(x) lpcnet_exp2((x)*1.44269504f)
 
 static inline float tanh_approx(float x)
 {
@@ -107,7 +107,7 @@ static inline void softmax(float *y, const float *x, int N)
 {
     int i;
     for (i=0;i<N;i++)
-        y[i] = celt_exp(x[i]);
+        y[i] = lpcnet_exp(x[i]);
 }
 
 static inline void vec_tanh(float *y, const float *x, int N)

--- a/src/vec_avx.h
+++ b/src/vec_avx.h
@@ -33,6 +33,7 @@
 #define VEC_AVX_H
 
 #include <immintrin.h>
+#include <math.h>
 
 /* Use 8-bit dot products unless disabled or if stuck with SSE2. */
 #if (defined(__AVX2__) || defined(__SSSE3__)) && !defined(DISABLE_DOT_PROD)

--- a/src/vec_avx.h
+++ b/src/vec_avx.h
@@ -41,7 +41,11 @@
 
 #else
 
+#if defined(_MSC_VER)
+#pragma message ("Only SSE and SSE2 are available. On newer machines, enable SSSE3/AVX/AVX2 to get better performance")
+#else
 #warning "Only SSE and SSE2 are available. On newer machines, enable SSSE3/AVX/AVX2 using -march= to get better performance"
+#endif
 
 #endif
 

--- a/src/vec_avx.h
+++ b/src/vec_avx.h
@@ -302,7 +302,7 @@ static inline __m256 exp8_approx(__m256 X)
    const __m256 K1 = _mm256_set1_ps(0.69583354f);
    const __m256 K2 = _mm256_set1_ps(0.22606716f);
    const __m256 K3 = _mm256_set1_ps(0.078024523f);
-   const __m256 log2_E = _mm256_set1_ps(1.44269504);
+   const __m256 log2_E = _mm256_set1_ps(1.44269504f);
    const __m256 max_in = _mm256_set1_ps(50.f);
    const __m256 min_in = _mm256_set1_ps(-50.f);
    __m256 XF, Y;

--- a/src/vec_avx.h
+++ b/src/vec_avx.h
@@ -519,7 +519,7 @@ static inline float sigmoid_approx(float x)
 
 #endif
 
-static inline float celt_exp(float x)
+static inline float lpcnet_exp(float x)
 {
    float out[8];
    __m256 X, Y;
@@ -540,7 +540,7 @@ static inline void softmax(float *y, const float *x, int N)
         _mm256_storeu_ps(&y[i], Y);
     }
     for (;i<N;i++)
-        y[i] = celt_exp(x[i]);
+        y[i] = lpcnet_exp(x[i]);
 }
 
 #ifdef __AVX__

--- a/src/vec_neon.h
+++ b/src/vec_neon.h
@@ -105,7 +105,7 @@ static inline float32x4_t sigmoid4_approx(float32x4_t X)
   return vmaxq_f32(min_out, vminq_f32(max_out, num));
 }
 
-static inline float celt_exp(float x)
+static inline float lpcnet_exp(float x)
 {
    float out[4];
    float32x4_t X, Y;
@@ -146,7 +146,7 @@ static inline void softmax(float *y, const float *x, int N)
         vst1q_f32(&y[i], Y);
     }
     for (;i<N;i++)
-        y[i] = celt_exp(x[i]);
+        y[i] = lpcnet_exp(x[i]);
 }
 
 static inline void vec_tanh(float *y, const float *x, int N)
@@ -162,7 +162,7 @@ static inline void vec_tanh(float *y, const float *x, int N)
     for (;i<N;i++)
     {
         float ex2;
-        ex2 = celt_exp(2*x[i]);
+        ex2 = lpcnet_exp(2*x[i]);
         y[i] = (ex2-1)/(ex2+1);
     }
 }
@@ -180,7 +180,7 @@ static inline void vec_sigmoid(float *y, const float *x, int N)
     for (;i<N;i++)
     {
         float ex;
-        ex = celt_exp(x[i]);
+        ex = lpcnet_exp(x[i]);
         y[i] = (ex)/(ex+1);
     }
 }


### PR DESCRIPTION
This PR includes 3 changes to allow for Lpcnet Opus WIP work on Windows.

Using the same function name celt_exp2 with what is already in the Opus repo seems to throw the compiler/linker off and we get a cryptic parameter list error message that makes no sense but renaming the function solves this.

Use pragma message as preprocessor directive warning is not supported on MSVC

Include a missing header for MSVC due to use of floor in avx code.

Note that this needs to be refactored for runtime detection of AVX on MSVC.

When compiling a C file with AVX instructions and the /AVX2 compiler flag on MSVC, and including the math.h header, there is a possibility of AVX2-specific math objects being brought in. However, due to the linker's random selection of objects depending on their order, AVX2 instructions may be inadvertently used in code that is not intended to have them. This can lead to crashes on older machines that do not support AVX2 instructions.